### PR TITLE
Make logging of cpu and timer data run on 1 node

### DIFF
--- a/helpers/helpers.yaml
+++ b/helpers/helpers.yaml
@@ -53,9 +53,9 @@ parameterset:
 
         srun ${affinity} python ${run_file} ${run_args}
 
-        srun -n 1 python ${base_path}/helpers/collect_timer_data.py ${log_path}
+        srun -n 1 --nodes 1 python ${base_path}/helpers/collect_timer_data.py ${log_path}
 
-        srun -n 1 python ${base_path}/helpers/cpu_logging.py ${jube_wp_abspath}
+        srun -n 1 --nodes 1 python ${base_path}/helpers/cpu_logging.py ${jube_wp_abspath}
 
         cat >job.json <<EOT
 


### PR DESCRIPTION
During benchmarking I realized that the logging of cpu data and timer data uses 1 MPI process. In case of a job with more Nodes than one slurm will raise a warning stating that one cannot use more Nodes than MPI processes. Thus I added added a flag explicitly requesting only 1 node for these operations.