### PR TITLE
Move default results path to new gin nest repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "results"]
 	path = results
-	url = https://gin.g-node.org/jasperalbers/benchmark-results.git
+	url = https://gin.g-node.org/nest/benchmark-results.git
 [submodule "models"]
 	path = models
 	url = https://github.com/INM-6/benchmark-models.git


### PR DESCRIPTION
Uses the (now official) repo for results. For new users everything will work out of the box; if you have already run `git submodule init` and `git submodule update` you need to manually change the following line:

In `results/.git/config` under `[remote "origin"]`:  change
```
url = https://gin.g-node.org/jasperalbers/benchmark-results.git
``` 
to
```
url = https://gin.g-node.org/nest/benchmark-results.git
```