### PR TITLE
Replace slurm by slurm_bench

### DIFF
--- a/benchmarks/hpc_benchmark_2.yaml
+++ b/benchmarks/hpc_benchmark_2.yaml
@@ -72,7 +72,7 @@ step:
       - from: hpc_benchmark_2_config.yaml
         _: file_paths,model_parameters,machine_parameters
       - from: helpers.yaml
-        _: slurm,run_benchmark,files,sub_bench_job,scaling_experiment,init_job_file_variables
+        _: slurm_bench,run_benchmark,files,sub_bench_job,scaling_experiment,init_job_file_variables
       do:
         done_file: $ready_file
         _: $submit_cmd --dependency=afterok:$$DEP $job_file

--- a/benchmarks/hpc_benchmark_3.yaml
+++ b/benchmarks/hpc_benchmark_3.yaml
@@ -72,7 +72,7 @@ step:
       - from: hpc_benchmark_3_config.yaml
         _: file_paths,model_parameters,machine_parameters
       - from: helpers.yaml
-        _: slurm,run_benchmark,files,sub_bench_job,scaling_experiment,init_job_file_variables
+        _: slurm_bench,run_benchmark,files,sub_bench_job,scaling_experiment,init_job_file_variables
       do:
         done_file: $ready_file
         _: $submit_cmd --dependency=afterok:$$DEP $job_file

--- a/benchmarks/hpc_benchmark_31.yaml
+++ b/benchmarks/hpc_benchmark_31.yaml
@@ -72,7 +72,7 @@ step:
       - from: hpc_benchmark_31_config.yaml
         _: file_paths,model_parameters,machine_parameters
       - from: helpers.yaml
-        _: slurm,run_benchmark,files,sub_bench_job,scaling_experiment,init_job_file_variables
+        _: slurm_bench,run_benchmark,files,sub_bench_job,scaling_experiment,init_job_file_variables
       do:
         done_file: $ready_file
         _: $submit_cmd --dependency=afterok:$$DEP  $job_file

--- a/benchmarks/microcircuit.yaml
+++ b/benchmarks/microcircuit.yaml
@@ -84,7 +84,7 @@ step:
       - from: microcircuit_config.yaml
         _: file_paths,model_parameters,machine_parameters
       - from: helpers.yaml
-        _: slurm,run_benchmark,files,sub_bench_job,scaling_experiment,init_job_file_variables
+        _: slurm_bench,run_benchmark,files,sub_bench_job,scaling_experiment,init_job_file_variables
       - model_files,simulation_substitutions
       do:
         done_file: $ready_file

--- a/benchmarks/multi-area-model_2.yaml
+++ b/benchmarks/multi-area-model_2.yaml
@@ -61,7 +61,7 @@ step:
       - from: multi-area-model_2_config.yaml
         _: file_paths,model_parameters,machine_parameters
       - from: helpers.yaml
-        _: slurm,run_benchmark,files,sub_bench_job,scaling_experiment
+        _: slurm_bench,run_benchmark,files,sub_bench_job,scaling_experiment
       do:
         done_file: $ready_file
         _: $submit_cmd --dependency=afterok:$$DEP  $job_file

--- a/benchmarks/multi-area-model_3.yaml
+++ b/benchmarks/multi-area-model_3.yaml
@@ -61,7 +61,7 @@ step:
       - from: multi-area-model_3_config.yaml
         _: file_paths,model_parameters,machine_parameters
       - from: helpers.yaml
-        _: slurm,run_benchmark,files,sub_bench_job,scaling_experiment
+        _: slurm_bench,run_benchmark,files,sub_bench_job,scaling_experiment
       do:
         done_file: $ready_file
         _: $submit_cmd --dependency=afterok:$$DEP $job_file

--- a/benchmarks/template.yaml
+++ b/benchmarks/template.yaml
@@ -74,7 +74,7 @@ step:
       - from: microcircuit_config.yaml
         _: file_paths,model_parameters,machine_parameters
       - from: helpers.yaml
-        _: slurm,run_benchmark,files,sub_bench_job,scaling_experiment,init_job_file_variables
+        _: slurm_bench,run_benchmark,files,sub_bench_job,scaling_experiment,init_job_file_variables
       - model_files,simulation_substitutions
       do:
         done_file: $ready_file

--- a/helpers/helpers.yaml
+++ b/helpers/helpers.yaml
@@ -50,7 +50,7 @@ substituteset:
         - {source: "#ACCOUNT#", dest: $account}
 
 parameterset:
-  - name: slurm
+  - name: slurm_bench
     parameter:
       - {name: submit_cmd, "_": sbatch }
       - {name: job_file, "_": job.slurm }


### PR DESCRIPTION
While reviewing the yaml files I noticed an asymmetry in naming:
In `helper.yaml`, we define two parameter sets for slurm, one for the build and one for the bench step.
The paramterset for the build step is named  `slurm_build`, the one for the bench step just `slurm`.
To get rid of this asymmetry, I renamed the latter `slurm_bench` and changed the name in the benchmark files accordingly. 