### PR TITLE
Rename: NEST benchmarking framework -> beNNch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 .ipynb_checkpoints
 
 # user config files
-.multi-area-model_*_*.xml
 *_config.xml
 *_config.yaml
 *_config.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "results"]
 	path = results
-	url = https://gin.g-node.org/nest/benchmark-results.git
+	url = https://gin.g-node.org/nest/beNNch-results.git
 	branch = main
 [submodule "models"]
 	path = models
-	url = https://github.com/INM-6/benchmark-models.git
+	url = https://github.com/INM-6/beNNch-models.git
 	branch = main
 [submodule "plot"]
 	path = plot
-	url = https://github.com/INM-6/benchplot.git
+	url = https://github.com/INM-6/beNNch-plot.git
 	branch = main

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- 
-NEST Benchmarking Framework - Unified execution, collection, analysis and
+beNNch - Unified execution, collection, analysis and
 comparison of neural network simulation benchmarks.
 Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 
@@ -16,7 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-# NEST Benchmarking Framework
+# beNNch
 
 ## Repository structure
 
@@ -28,13 +28,13 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 *analysis* contains JUBE analysis script, config and helpers.
 
-*models* is a git submodule; the linked repository (`https://github.com/INM-6/benchmark-models`) contains NEST network models adapted to work with the benchmarking framework.
+*models* is a git submodule; the linked repository (`https://github.com/INM-6/beNNch-models`) contains NEST network models adapted to work with `beNNch`.
 
-*plot* is a git submodule; the linked repository (`https://github.com/INM-6/benchplot`) contains predefined plotting routines designed to process the performance results and provide a standardized plotting format.
+*plot* is a git submodule; the linked repository (`https://github.com/INM-6/beNNch-plot`) contains predefined plotting routines designed to process the performance results and provide a standardized plotting format.
 
 *results* TODO
 
-## Using the framework
+## User guide
 
 ### Initialization
 
@@ -148,7 +148,7 @@ First, create a new instance of the analysis configuration with
 cp analysis/analysis_config_template.py analysis/analysis_config.py
 ```
 Here, fill in
-- whether the scaling benchmark runs across threads or nodes. This sets up a quick, glanceable plot of the benchmark to confirm that no substantial errors occurred. The framework provides defaults for plotting timers across `nodes` and `threads`, but alternatives can be readily implemented by adding to `analysis/plot_helpers.py`.
+- whether the scaling benchmark runs across threads or nodes. This sets up a quick, glanceable plot of the benchmark to confirm that no substantial errors occurred. `beNNch` provides defaults for plotting timers across `nodes` and `threads`, but alternatives can be readily implemented by adding to `analysis/plot_helpers.py`.
 - the path to the JUBE output (usually the same as the `outpath` of the `<benchmark>` in `benchmarks/<model>`)
 
 To start the analysis, execute
@@ -210,13 +210,13 @@ with an arbitrarily long list of bullet items (consisting of metadata keys) that
   + [issue](https://github.com/jupyter/nbconvert/issues/1394) with a recent version of `nbconvert`, try to install version `5.6.1` instead (e.g. `pip install nbconvert==5.6.1 --user`)
 
 ___
-## Developing the framework
+## Developer guide
 
 ### Add a new model
 
 `benchmarks/template.yaml` provides a template for a JUBE benchmarking script and can be used as a starting point for adding a new model. Here, only the marked section needs to be adapted. As a reference, see the implementation of the microcircuit in `benchmarks/microcircuit.yaml`.
 
-In addition, minor modifications to a regular network model need to be made in order to comply with the framework's standards. In particular, this concerns how JUBE feeds the configuration parameters to the network and how JUBE reads the performance measurement output.
+In addition, minor modifications to a regular network model need to be made in order to comply with `beNNch`'s standards. In particular, this concerns how JUBE feeds the configuration parameters to the network and how JUBE reads the performance measurement output.
 
 #### Input
 
@@ -224,4 +224,4 @@ A new model needs to be able to receive input from JUBE for setting parameters. 
 
 #### Output
 
-As current releases of NEST (including 2.14.1, 2.20.2 and 3.0+) include timers on the C++ level for measuring the simulation performance, the model only needs to output this information in a way compliant with the framework. This can be done via adding a call to the `logging` function defined in `models/Potjans_2014/bm_helpers.py`. Note that this also provides the optional functionality to include python level timers as well as memory information.
+As current releases of NEST (including 2.14.1, 2.20.2 and 3.0+) include timers on the C++ level for measuring the simulation performance, the model only needs to output this information in a way compliant with `beNNch`. This can be done via adding a call to the `logging` function defined in `models/Potjans_2014/bm_helpers.py`. Note that this also provides the optional functionality to include python level timers as well as memory information.

--- a/analysis/analysis.py
+++ b/analysis/analysis.py
@@ -1,5 +1,5 @@
 """
-NEST Benchmarking Framework - Unified execution, collection, analysis and
+beNNch - Unified execution, collection, analysis and
 comparison of neural network simulation benchmarks.
 Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/analysis/analysis_config_template.py
+++ b/analysis/analysis_config_template.py
@@ -1,5 +1,5 @@
 """
-NEST Benchmarking Framework - Unified execution, collection, analysis and
+beNNch - Unified execution, collection, analysis and
 comparison of neural network simulation benchmarks.
 Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/analysis/analysis_helper.py
+++ b/analysis/analysis_helper.py
@@ -1,5 +1,5 @@
 """
-NEST Benchmarking Framework - Unified execution, collection, analysis and
+beNNch - Unified execution, collection, analysis and
 comparison of neural network simulation benchmarks.
 Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/analysis/plot_helper.py
+++ b/analysis/plot_helper.py
@@ -1,5 +1,5 @@
 """
-NEST Benchmarking Framework - Unified execution, collection, analysis and
+beNNch - Unified execution, collection, analysis and
 comparison of neural network simulation benchmarks.
 Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/benchmarks/hpc_benchmark_2.yaml
+++ b/benchmarks/hpc_benchmark_2.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/benchmarks/hpc_benchmark_3.yaml
+++ b/benchmarks/hpc_benchmark_3.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/benchmarks/hpc_benchmark_31.yaml
+++ b/benchmarks/hpc_benchmark_31.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/benchmarks/microcircuit.yaml
+++ b/benchmarks/microcircuit.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/benchmarks/multi-area-model_2.yaml
+++ b/benchmarks/multi-area-model_2.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/benchmarks/multi-area-model_3.yaml
+++ b/benchmarks/multi-area-model_3.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/benchmarks/template.yaml
+++ b/benchmarks/template.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/config/templates/hpc_benchmark_config_template.yaml
+++ b/config/templates/hpc_benchmark_config_template.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/config/templates/microcircuit_config_template.yaml
+++ b/config/templates/microcircuit_config_template.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/config/templates/multi-area-model_2_config_template.yaml
+++ b/config/templates/multi-area-model_2_config_template.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/config/templates/multi-area-model_3_config_template.yaml
+++ b/config/templates/multi-area-model_3_config_template.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/config/templates/user_config_template.yaml
+++ b/config/templates/user_config_template.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/helpers/collect_timer_data.py
+++ b/helpers/collect_timer_data.py
@@ -1,5 +1,5 @@
 """
-NEST Benchmarking Framework - Unified execution, collection, analysis and
+beNNch - Unified execution, collection, analysis and
 comparison of neural network simulation benchmarks.
 Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/helpers/cpu_logging.py
+++ b/helpers/cpu_logging.py
@@ -1,5 +1,5 @@
 """
-NEST Benchmarking Framework - Unified execution, collection, analysis and
+beNNch - Unified execution, collection, analysis and
 comparison of neural network simulation benchmarks.
 Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/helpers/helpers.yaml
+++ b/helpers/helpers.yaml
@@ -1,4 +1,4 @@
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/helpers/job.slurm.in
+++ b/helpers/job.slurm.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 # comparison of neural network simulation benchmarks.
 # Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 

--- a/helpers/metadata_archive.py
+++ b/helpers/metadata_archive.py
@@ -1,6 +1,22 @@
 #!/usr/bin/env python
 # encoding: utf8
 
+# beNNch - Unified execution, collection, analysis and
+# comparison of neural network simulation benchmarks.
+# Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
+
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <https://www.gnu.org/licenses/>.
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 import os
 import sys
 import time
@@ -77,7 +93,8 @@ class Recorder(object):
                 with Popen(shlex.split(command.format(**parameters)),
                            stdout=PIPE, stderr=PIPE, stdin=DEVNULL) as infile:
                     try:
-                        (stdout_data, stderr_data) = infile.communicate(timeout=self.timeout)
+                        (stdout_data, stderr_data) = infile.communicate(
+                            timeout=self.timeout)
                     except TimeoutExpired:
                         log.warning(
                             "%s: process did not finish in time! Output will be"
@@ -98,7 +115,8 @@ class Recorder(object):
                             errfile.write(stderr_data)
                             if self.errors_fatal:
                                 log.fatal("ERRORS are configured to be fatal.")
-                                raise ValueError("Process wrote errors to STDERR!")
+                                raise ValueError(
+                                    "Process wrote errors to STDERR!")
                     iotime = time.time()
             except CalledProcessError as e:
                 log.error("%s: called process failed! retrun code: %d",

--- a/slideshow/slideshow.py
+++ b/slideshow/slideshow.py
@@ -1,5 +1,5 @@
 """
-NEST Benchmarking Framework - Unified execution, collection, analysis and
+# beNNch - Unified execution, collection, analysis and
 comparison of neural network simulation benchmarks.
 Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
 


### PR DESCRIPTION
Rename all occurrences of "NEST benchmarking framework" or similar to "beNNch", includes updating links to renamed submodules.