### PR TITLE
Fix inconsistency in analysis variable naming

### DIFF
--- a/config/templates/analysis_config_template.yaml
+++ b/config/templates/analysis_config_template.yaml
@@ -15,4 +15,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 scaling_type: "" # scaling type as used by analysis/plot_helper.py
-jube_bench_path: "" # path to jube benchmarking output, should the same as the 'outpath' defined in benchmarks/<your_model>.yaml
+jube_outpath: "" # path to jube benchmarking output, should the same as the 'outpath' defined in benchmarks/<your_model>.yaml


### PR DESCRIPTION
`jube_bench_path` -> `jube_outpath`

Fixes #39.