### PR TITLE
Add contribution and citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,7 @@ A new model needs to be able to receive input from JUBE for setting parameters. 
 #### Output
 
 As current releases of NEST (including 2.14.1, 2.20.2 and 3.0+) include timers on the C++ level for measuring the simulation performance, the model only needs to output this information in a way compliant with `beNNch`. This can be done via adding a call to the `logging` function defined in `models/Potjans_2014/bm_helpers.py`. Note that this also provides the optional functionality to include python level timers as well as memory information.
+
+## How to cite beNNch
+
+We recommend to provide a link to this repository with the hash of the respective commit.

--- a/contributors.md
+++ b/contributors.md
@@ -1,3 +1,21 @@
+<!-- 
+beNNch - Unified execution, collection, analysis and
+comparison of neural network simulation benchmarks.
+Copyright (C) 2021 Forschungszentrum Juelich GmbH, INM-6
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
 # Authors and contributors
 
 The following people have contributed code and/or ideas to the current version of beNNch.

--- a/contributors.md
+++ b/contributors.md
@@ -1,0 +1,25 @@
+# Authors and contributors
+
+The following people have contributed code and/or ideas to the current version of beNNch.
+The intitutional affiliations are those at the time of the contribution, and may not be the current affiliation of a contributor.
+
+Jasper Albers [1,2]
+Johanna Senk [1]
+Jari Pronold [1,2]
+Anno Kurth [1,2]
+Stine Brekke Vennemo [3]
+Kaveh Haghighi Mood [4]
+Alexander Patronis [4]
+Dennis Terhorst [1]
+Jakob Jordan [5]
+Susanne Kunkel [3]
+Tom Tetzlaff [1]
+Markus Diesmann [1]
+
+[1] Institute of Neuroscience and Medicine (INM-6) and Institute for Advanced Simulation (IAS-6) and JARA-Institute Brain Structure-Function Relationships (INM-10), Jülich Research Centre, Jülich, Germany
+[2] RWTH Aachen University, Aachen, Germany
+[3] Faculty of Science and Technology, Norwegian University of Life Sciences, Ås, Norway
+[4] Jülich Supercomputing Centre (JSC), Jülich Research Centre, Jülich, Germany
+[5] Department of Physiology, University of Bern, Bern, Switzerland
+[6] Department of Physics, Faculty 1, RWTH Aachen University, Aachen, Germany
+[7] Department of Psychiatry, Psychotherapy and Psychosomatics, School of Medicine, RWTH Aachen University, Aachen, Germany


### PR DESCRIPTION
Add contributors and how to cite the framework. The latter might be adapted if we choose to go with a Zenodo DOI.