### PR TITLE
Fix collection of timer information

### DIFF
--- a/helpers/collect_timer_data.py
+++ b/helpers/collect_timer_data.py
@@ -85,8 +85,9 @@ for logfile in all_logfiles:
     with open(logfile, 'r') as fn:
         log = {}
         for line in fn:
-            key, value = line.split(' ')
-            log[key] = float(value)
+            key, value, *_ = line.split(' ')
+            if key in metrics + metrics_sum:
+                log[key] = float(value)
 
         for m in d:
             try:


### PR DESCRIPTION
The [PR 3](https://github.com/INM-6/beNNch-models/pull/3) of [beNNch-models]((https://github.com/INM-6/beNNch-models/) changed the content of the logging files: They now also contain all of the `nest.GetKernelStatus()` dictionary. This leads to problems when collecting the timer information: 1) The content of a line can possibly have more than two entries. 2) Not all entries are of interest for further timer analysis.

This PR fixes both problems. Any entry that does not fit into the `key, value` scheme is written into a throwaway list. Any entry that is not part of the metrics of interest is disregarded.

I have tried it with the microcircuit but I don't see a reason why it should behave differently with the other models.