### PR TITLE
Microcircuit template need `'spike_recorder'` not `'spike_detector'` for recording spikes

### DIFF
--- a/config/templates/microcircuit_config_template.yaml
+++ b/config/templates/microcircuit_config_template.yaml
@@ -32,7 +32,7 @@ parameterset:
        - {name: model_time_sim, type: float, _: "1000."}  # biological time to be simulated in ms
        - {name: model_time_presim, _: "100."}  # in ms
        - {name: rng_seed, _: "55"}  # rng seed
-       - {name: record_spikes, type: string, _: ""}  # change to 'spike_detector' for spike recordings
+       - {name: record_spikes, type: string, _: ""}  # change to 'spike_recorder' for spike recordings
        - {name: kwds, separator: ;, type: string, _: "{}"}  # can be used for passing arguments to SetKernelStatus, such as max_buffer_size_spike_data. If no arguments should be passed leave this empty. If something should be passed insert a dictionary, eg: {'max_buffer_size_spike_data': 10}
        - {name: scaling_type, _: "strong"}  # can be either weak or strong
     - name: machine_parameters


### PR DESCRIPTION
See [microcircuit sim_params](https://github.com/INM-6/beNNch-models/blob/3fcefd9760b33460276dcbd9ea23b7791572a105/Potjans_2014/sim_params.py#L40-L43).