### PR TITLE
Update for the bugfix in JUBE 2.4.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,8 @@ tar -xzf git-annex-standalone-amd64.tar.gz
 export PATH=$PATH:<install_path>/git-annex.linux
 ```
 - [JUBE](https://www.fz-juelich.de/ias/jsc/EN/Expertise/Support/Software/JUBE/_node.html)  
-_Note that if you are using the JUBE version 2.4.1 or lower, the following export command is required for executing benchmarks due to a known bug. Once the bug is fixed, the export will become unnecessary and the documentation here will be updated accordingly._
+_Note that  JUBE version 2.4.2 or later is necessary_
 
-```bash
-export JUBE_INCLUDE_PATH="<PATH_TO_REPO>config/:helpers/"
-```
 
 - [Builder](https://github.com/INM-6/Builder)
   + see Builder documentation for installation guide

--- a/benchmarks/hpc_benchmark_2.yaml
+++ b/benchmarks/hpc_benchmark_2.yaml
@@ -14,10 +14,10 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# include-path: # not working due to a bug in JUBE. Uncomment after next release! 
-#   path: 
-#    - ../helpers/
-#    - ../config/
+include-path: 
+  path: 
+   - ../helpers/
+   - ../config/
 
 # model-specific name and output path
 name: HPC

--- a/benchmarks/hpc_benchmark_3.yaml
+++ b/benchmarks/hpc_benchmark_3.yaml
@@ -14,10 +14,10 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# include-path: # not working due to a bug in JUBE. Uncomment after next release! 
-#   path: 
-#    - ../helpers/
-#    - ../config/
+include-path:  
+  path: 
+   - ../helpers/
+   - ../config/
 
 # model-specific name and output path
 name: HPC

--- a/benchmarks/hpc_benchmark_31.yaml
+++ b/benchmarks/hpc_benchmark_31.yaml
@@ -14,10 +14,10 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# include-path: # not working due to a bug in JUBE. Uncomment after next release! 
-#   path: 
-#    - ../helpers/
-#    - ../config/
+include-path:
+  path: 
+   - ../helpers/
+   - ../config/
 
 # model-specific name and output path
 name: HPC

--- a/benchmarks/microcircuit.yaml
+++ b/benchmarks/microcircuit.yaml
@@ -14,10 +14,10 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# include-path: # not working due to a bug in JUBE. Uncomment after next release! 
-#   path: 
-#    - ../helpers/
-#    - ../config/
+include-path: 
+  path: 
+   - ../helpers/
+   - ../config/
 
 name: microcircuit
 # model-specific name and output path

--- a/benchmarks/multi-area-model_2.yaml
+++ b/benchmarks/multi-area-model_2.yaml
@@ -14,10 +14,10 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# include-path: # not working due to a bug in JUBE. Uncomment after next release! 
-#   path: 
-#    - ../helpers/
-#    - ../config/
+include-path: 
+  path: 
+   - ../helpers/
+   - ../config/
 
 # model-specific name and output path
 name: MAM

--- a/benchmarks/multi-area-model_3.yaml
+++ b/benchmarks/multi-area-model_3.yaml
@@ -14,10 +14,10 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# include-path: # not working due to a bug in JUBE. Uncomment after next release! 
-#   path: 
-#    - ../helpers/
-#    - ../config/
+include-path:
+  path: 
+   - ../helpers/
+   - ../config/
 
 # model-specific name and output path
 name: MAM

--- a/benchmarks/template.yaml
+++ b/benchmarks/template.yaml
@@ -14,10 +14,10 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# include-path: # not working due to a bug in JUBE. Uncomment after next release! 
-#   path: 
-#    - ../helpers/
-#    - ../config/
+include-path:
+  path: 
+   - ../helpers/
+   - ../config/
 
 ### EDIT BELOW
 


### PR DESCRIPTION
Due to a bugfix in JUBE 2.4.2. We can avoid setting PATHs with env variables which is easier for users. On the other hand, the framework would not work with older JUBE versions.  