### PR TITLE
Move import in HPC-benchmark file to the correct place

### DIFF
--- a/benchmarks/hpc_benchmark_31.yaml
+++ b/benchmarks/hpc_benchmark_31.yaml
@@ -70,8 +70,8 @@ step:
       - from: user_config.yaml
         _: user_config
       - from: hpc_benchmark_31_config.yaml
-      - from: helpers.yaml
         _: file_paths,model_parameters,machine_parameters,software_parameters
+      - from: helpers.yaml
         _: slurm_bench,run_benchmark,files,sub_bench_job,scaling_experiment,init_job_file_variables
       do:
         done_file: $ready_file


### PR DESCRIPTION
Before, the code tried to import configuration parameter from `helpers.yaml` instead of the config file.